### PR TITLE
Improved updating of Client registration

### DIFF
--- a/leshan-core/src/main/java/leshan/server/lwm2m/client/Client.java
+++ b/leshan-core/src/main/java/leshan/server/lwm2m/client/Client.java
@@ -62,7 +62,7 @@ public class Client {
 
     private final String registrationId;
 
-    private final String[] objectLinks;
+    private String[] objectLinks;
 
     private Date lastUpdate;
 
@@ -118,6 +118,10 @@ public class Client {
         return objectLinks;
     }
 
+    public void setObjectLinks(String[] objectLinks) {
+        this.objectLinks = objectLinks;
+    }
+
     public long getLifeTimeInSec() {
         return lifeTimeInSec;
     }
@@ -167,10 +171,11 @@ public class Client {
     }
 
     public void setLastUpdate(Date lastUpdate) {
+        // TODO should probably better be done "implicitly" as part of the other setters
         this.lastUpdate = lastUpdate;
     }
 
-    public void markLastRequestFaild() {
+    public void markLastRequestFailed() {
         this.failedLastRequest = true;
     }
 

--- a/leshan-core/src/main/java/leshan/server/lwm2m/resource/RegisterResource.java
+++ b/leshan-core/src/main/java/leshan/server/lwm2m/resource/RegisterResource.java
@@ -58,6 +58,16 @@ import ch.ethz.inf.vs.californium.server.resources.ResourceBase;
  */
 public class RegisterResource extends ResourceBase {
 
+    private static final String QUERY_PARAM_ENDPOINT = "ep=";
+
+    private static final String QUERY_PARAM_BINDING_MODE = "b=";
+
+    private static final String QUERY_PARAM_LWM2M_VERSION = "lwm2m=";
+
+    private static final String QUERY_PARAM_SMS = "sms=";
+
+    private static final String QUERY_PARAM_LIFETIME = "lt=";
+
     private static final Logger LOG = LoggerFactory.getLogger(RegisterResource.class);
 
     public static final String RESOURCE_NAME = "rd";
@@ -91,18 +101,19 @@ public class RegisterResource extends ResourceBase {
         String smsNumber = null;
         String lwVersion = null;
         BindingMode binding = null;
+        String[] objectLinks = null;
         try {
 
             for (String param : request.getOptions().getURIQueries()) {
-                if (param.startsWith("ep=")) {
+                if (param.startsWith(QUERY_PARAM_ENDPOINT)) {
                     endpoint = param.substring(3);
-                } else if (param.startsWith("lt=")) {
+                } else if (param.startsWith(QUERY_PARAM_LIFETIME)) {
                     lifetime = Long.valueOf(param.substring(3));
-                } else if (param.startsWith("sms=")) {
+                } else if (param.startsWith(QUERY_PARAM_SMS)) {
                     smsNumber = param.substring(4);
-                } else if (param.startsWith("lwm2m=")) {
+                } else if (param.startsWith(QUERY_PARAM_LWM2M_VERSION)) {
                     lwVersion = param.substring(6);
-                } else if (param.startsWith("b=")) {
+                } else if (param.startsWith(QUERY_PARAM_BINDING_MODE)) {
                     binding = BindingMode.valueOf(param.substring(2));
                 }
             }
@@ -112,8 +123,9 @@ public class RegisterResource extends ResourceBase {
             } else {
                 // register
                 String registrationId = RegisterResource.createRegistrationId();
-
-                String[] objectLinks = new String(request.getPayload(), Charsets.UTF_8).split(",");
+                if (request.getPayload() != null) {
+                    objectLinks = new String(request.getPayload(), Charsets.UTF_8).split(",");
+                }
 
                 Client client = new Client(registrationId, endpoint, request.getSource(), request.getSourcePort(),
                         lwVersion, lifetime, smsNumber, binding, objectLinks);
@@ -154,19 +166,26 @@ public class RegisterResource extends ResourceBase {
         String smsNumber = null;
         String lwVersion = null;
         BindingMode binding = null;
+        String [] objectLinks = null;
+
         for (String param : request.getOptions().getURIQueries()) {
-            if (param.startsWith("lt=")) {
+            if (param.startsWith(QUERY_PARAM_LIFETIME)) {
                 lifetime = Long.valueOf(param.substring(3));
-            } else if (param.startsWith("sms=")) {
+            } else if (param.startsWith(QUERY_PARAM_SMS)) {
                 smsNumber = param.substring(4);
-            } else if (param.startsWith("lwm2m=")) {
+            } else if (param.startsWith(QUERY_PARAM_LWM2M_VERSION)) {
                 lwVersion = param.substring(6);
-            } else if (param.startsWith("b=")) {
+            } else if (param.startsWith(QUERY_PARAM_BINDING_MODE)) {
                 binding = BindingMode.valueOf(param.substring(2));
             }
         }
+        
+        if (request.getPayload() != null) {
+            objectLinks = new String(request.getPayload(), Charsets.UTF_8).split(",");    
+        }
+
         ClientUpdate client = new ClientUpdate(registrationId, request.getSource(), request.getSourcePort(), lwVersion,
-                lifetime, smsNumber, binding, null);
+                lifetime, smsNumber, binding, objectLinks);
 
         try {
             Client c = this.registry.updateClient(client);


### PR DESCRIPTION
I have added code to update a Client's object links and "touch" the lastUpdated property when a Client updates its registration.

I was wondering whether the clean-up interval in the registry is a little "aggressive", i.e. I think it would be sufficient to do the clean-up every couple of minutes instead of seconds ... what do you think?
