### PR TITLE
Generic support for multiple CoAP Endpoints

### DIFF
--- a/leshan-core/src/main/java/leshan/server/lwm2m/resource/RegisterResource.java
+++ b/leshan-core/src/main/java/leshan/server/lwm2m/resource/RegisterResource.java
@@ -29,6 +29,7 @@
  */
 package leshan.server.lwm2m.resource;
 
+import java.net.InetSocketAddress;
 import java.util.List;
 
 import leshan.server.lwm2m.client.BindingMode;
@@ -45,7 +46,6 @@ import org.slf4j.LoggerFactory;
 import ch.ethz.inf.vs.californium.coap.CoAP.ResponseCode;
 import ch.ethz.inf.vs.californium.coap.CoAP.Type;
 import ch.ethz.inf.vs.californium.coap.Request;
-import ch.ethz.inf.vs.californium.network.Endpoint;
 import ch.ethz.inf.vs.californium.server.resources.CoapExchange;
 import ch.ethz.inf.vs.californium.server.resources.Resource;
 import ch.ethz.inf.vs.californium.server.resources.ResourceBase;
@@ -75,13 +75,10 @@ public class RegisterResource extends ResourceBase {
 
     private final ClientRegistry registry;
 
-    private final Endpoint endpointSecure;
-
-    public RegisterResource(ClientRegistry registry, Endpoint endpointSecure) {
+    public RegisterResource(ClientRegistry registry) {
         super(RESOURCE_NAME);
 
         this.registry = registry;
-        this.endpointSecure = endpointSecure;
         getAttributes().addResourceType("core.rd");
     }
 
@@ -131,11 +128,11 @@ public class RegisterResource extends ResourceBase {
                     objectLinks = new String(request.getPayload(), Charsets.UTF_8).split(",");
                 }
 
-                // is the registration is coming from the secure endpoint?
-                boolean secure = exchange.advanced().getEndpoint() == endpointSecure;
+                // which end point did the client post this request to?
+                InetSocketAddress registrationEndpoint = exchange.advanced().getEndpoint().getAddress();
 
                 Client client = new Client(registrationId, endpoint, request.getSource(), request.getSourcePort(),
-                        lwVersion, lifetime, smsNumber, binding, objectLinks, secure);
+                        lwVersion, lifetime, smsNumber, binding, objectLinks, registrationEndpoint);
 
                 registry.registerClient(client);
                 LOG.debug("New registered client: {}", client);

--- a/leshan-core/src/test/java/leshan/server/lwm2m/client/ClientRegistryImplTest.java
+++ b/leshan-core/src/test/java/leshan/server/lwm2m/client/ClientRegistryImplTest.java
@@ -30,6 +30,7 @@
 package leshan.server.lwm2m.client;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -50,46 +51,48 @@ public class ClientRegistryImplTest {
 
     @Before
     public void setUp() throws Exception {
-        this.address = InetAddress.getLocalHost();
-        this.registry = new ClientRegistryImpl();
+        address = InetAddress.getLocalHost();
+        registry = new ClientRegistryImpl();
 
     }
 
     @Test
     public void testUpdateClientKeepsUnchangedProperties() {
-        givenASimpleClient(this.lifetime);
-        this.registry.registerClient(this.client);
+        givenASimpleClient(lifetime);
+        registry.registerClient(client);
 
-        ClientUpdate clientUpdate = new ClientUpdate(this.registrationId, this.address, this.port);
-        this.registry.updateClient(clientUpdate);
+        ClientUpdate clientUpdate = new ClientUpdate(registrationId, address, port);
+        registry.updateClient(clientUpdate);
 
-        Client registeredClient = this.registry.get(this.ep);
-        Assert.assertEquals((long) this.lifetime, registeredClient.getLifeTimeInSec());
-        Assert.assertSame(this.binding, registeredClient.getBindingMode());
-        Assert.assertEquals(this.sms, registeredClient.getSmsNumber());
+        Client registeredClient = registry.get(ep);
+        Assert.assertEquals((long) lifetime, registeredClient.getLifeTimeInSec());
+        Assert.assertSame(binding, registeredClient.getBindingMode());
+        Assert.assertEquals(sms, registeredClient.getSmsNumber());
     }
 
     @Test
     public void testRegisterClientSetsTimeToLive() {
-        givenASimpleClient(this.lifetime);
-        this.registry.registerClient(this.client);
-        Assert.assertTrue(this.client.isAlive());
+        givenASimpleClient(lifetime);
+        registry.registerClient(client);
+        Assert.assertTrue(client.isAlive());
     }
 
     @Test
     public void testUpdateClientExtendsTimeToLive() {
         givenASimpleClient(0L);
-        this.registry.registerClient(this.client);
-        Assert.assertFalse(this.client.isAlive());
+        registry.registerClient(client);
+        Assert.assertFalse(client.isAlive());
 
-        ClientUpdate clientUpdate = new ClientUpdate(this.registrationId, this.address, this.port, this.lifetime, null,
+        ClientUpdate clientUpdate = new ClientUpdate(registrationId, address, port, lifetime, null,
                 null, null);
-        this.registry.updateClient(clientUpdate);
-        Assert.assertTrue(this.client.isAlive());
+        registry.updateClient(clientUpdate);
+        Assert.assertTrue(client.isAlive());
     }
 
     private void givenASimpleClient(Long lifetime) {
-        this.client = new Client(this.registrationId, this.ep, this.address, this.port, null, lifetime, this.sms,
-                this.binding, this.objectLinks, null, false);
+
+        client = new Client(registrationId, ep, address, port, null, lifetime, sms,
+                binding, objectLinks, null,
+                InetSocketAddress.createUnresolved("localhost", 5683));
     }
 }

--- a/leshan-core/src/test/java/leshan/server/lwm2m/message/californium/BasicTestSupport.java
+++ b/leshan-core/src/test/java/leshan/server/lwm2m/message/californium/BasicTestSupport.java
@@ -1,6 +1,7 @@
 package leshan.server.lwm2m.message.californium;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Date;
 
@@ -11,9 +12,11 @@ public abstract class BasicTestSupport {
     Client client;
     InetAddress destination;
     int destinationPort = 5000;
+    InetSocketAddress registrationAddress;
 
     void givenASimpleClient() throws UnknownHostException {
-        this.client = new Client("ID", "urn:client", InetAddress.getLocalHost(), 5683, "1.0", 10000L, null, null, null,
-                new Date(), false);
+        registrationAddress = InetSocketAddress.createUnresolved("localhost", 5683);
+        client = new Client("ID", "urn:client", InetAddress.getLocalHost(), 10000, "1.0", 10000L, null, null, null,
+                new Date(), registrationAddress);
     }
 }


### PR DESCRIPTION
I have introduced generic support for an arbitrary set of CoAP endpoints leshan can serve its services on. A LWM2M Client may use any one of them to register with the server, e.g. the underlying Californium server may be configured with a non-secure endpoint on standard port 5683 and a secure one on 5684 (as Simon already added to LwM2mServer). However, the number of endpoints supported is not limited to two.

For the purposes of managing the client, the server does not really care whether the underlying CoAP stack uses DTLS or not. However, it will be important, that the server uses the same endpoint to issue requests to the client as the client initially used to register with the server. This is particularly important in cases where the client is behind a firewall that only forwards inbound UDP packets originating from the target of the client's initial outbound (registration) request.

In order for the RequestHandler to be able to find out, which Endpoint should be used to talk to the client, I have introduced the `registrationEndpointAddress` property to class `Client` which is used to store the address of the `Endpoint` through which the client's registration request came in. I have removed the `secure` flag from `Client` which seemed to serve a similar purpose but is no longer needed. The processing logic does not really care, whether the request's payload has been transmitted using DTLS or not. If at some point we need to be able to determine the client's identity (authenticated during DTLS handshake) we need to use some explicit API provided by the underlying Californium stack from my point of view - maybe something along the lines of the Servlet API, i.e. something like `Request.getPrincipal()`...

What do you think?
