### PR TITLE
Set application/link-format to ID 40 as per RFC7252

### DIFF
--- a/leshan-core/src/main/java/leshan/server/lwm2m/message/ContentFormat.java
+++ b/leshan-core/src/main/java/leshan/server/lwm2m/message/ContentFormat.java
@@ -35,7 +35,7 @@ package leshan.server.lwm2m.message;
 public enum ContentFormat {
 
     // TODO: update media type codes once they have been assigned by IANA
-    LINK("application/link-format", 1540), TEXT("application/vnd.oma.lwm2m+text", 1541), TLV(
+    LINK("application/link-format", 40), TEXT("application/vnd.oma.lwm2m+text", 1541), TLV(
             "application/vnd.oma.lwm2m+tlv", 1542), JSON("application/vnd.oma.lwm2m+json", 1543), OPAQUE(
                     "application/vnd.oma.lwm2m+opaque", 1544);
 


### PR DESCRIPTION
CoAP has been assigned RFC7252. In doing so, the CoAP Content-Formats Registry has also assigned an official value of 40 for application/link-format.
