### PR TITLE
Extension of LinkObject 

### DIFF
--- a/leshan-core/src/main/java/leshan/server/lwm2m/client/Client.java
+++ b/leshan-core/src/main/java/leshan/server/lwm2m/client/Client.java
@@ -220,6 +220,10 @@ public class Client {
     public synchronized void markLastRequestFailed() {
         failedLastRequest = true;
     }
+    
+    public synchronized boolean isMarkLastRequestFailed(){
+        return failedLastRequest;
+    }
 
     public synchronized boolean isAlive() {
         return failedLastRequest ? false : lastUpdate.getTime() + lifeTimeInSec * 1000 > System.currentTimeMillis();

--- a/leshan-core/src/main/java/leshan/server/lwm2m/client/LinkObject.java
+++ b/leshan-core/src/main/java/leshan/server/lwm2m/client/LinkObject.java
@@ -32,12 +32,20 @@ package leshan.server.lwm2m.client;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class LinkObject {
 
     private final String url;
 
     private final Map<String, Object> attributes;
+
+    private Integer objectId;
+
+    private Integer objectInstanceId;
+
+    private Integer resourceId;
 
     /**
      * Creates a new link object without attributes.
@@ -61,6 +69,7 @@ public class LinkObject {
         } else {
             this.attributes = Collections.unmodifiableMap(new HashMap<String, Object>());
         }
+        setIdsFromObjectLink(url);
     }
 
     /**
@@ -84,5 +93,48 @@ public class LinkObject {
     @Override
     public String toString() {
         return String.format("LinkObject [url=%s, attributes=%s]", url, attributes);
+    }
+
+    public Integer getObjectId() {
+        return objectId;
+    }
+
+    public Integer getObjectInstanceId() {
+        return objectInstanceId;
+    }
+
+    public Integer getResourceId() {
+        return resourceId;
+    }
+
+    private void setObjectId(Integer objectId) {
+        this.objectId = objectId;
+    }
+
+    private void setObjectInstanceId(Integer objectInstanceId) {
+        this.objectInstanceId = objectInstanceId;
+    }
+
+    private void setResourceId(Integer resourceId) {
+        this.resourceId = resourceId;
+    }
+
+    private void setIdsFromObjectLink(String url) {
+
+        String pattern = "(/(\\d+))(/(\\d+))?(/(\\d+))?";
+        Pattern pat = Pattern.compile(pattern);
+        Matcher mat = pat.matcher(url);
+
+        if (mat.find()) {
+            if (mat.group(2) != null) {
+                this.setObjectId(new Integer(mat.group(2)));
+            }
+            if (mat.group(4) != null) {
+                this.setObjectInstanceId(new Integer(mat.group(4)));
+            }
+            if (mat.group(6) != null) {
+                this.setResourceId(new Integer(mat.group(6)));
+            }
+        }
     }
 }


### PR DESCRIPTION
Hello Julien,
Concerning Your post in https://groups.google.com/forum/#!topic/leshan-lwm2m/sAnl2x1O4dE to link format paring, 
I like the the new  ‘LinkObject’  Object and I have the following proposal:
I would like to have access to objectId, objectInstanceId and resourceId for each ‘objectLink’ Element. Thus we have simple access from the Client Object to its attributes like this:

`clientDevice.getObjectLinks()[i].getObjectId())`

Besides, the  boolean MarkLastRequestFailed has now a getter Method `isMarkLastRequestFailed()` because we need it for lifetime invalidation in our own Client Implementation.

Best Regards
Ingo Schaal
