### PR TITLE
fixed CANCEL observe issue clientServlet.java

### DIFF
--- a/leshan-standalone/src/main/java/leshan/standalone/servlet/ClientServlet.java
+++ b/leshan-standalone/src/main/java/leshan/standalone/servlet/ClientServlet.java
@@ -1,7 +1,75 @@
+/*
  * Copyright (c) 2013, Sierra Wireless
+ * Copyright (c) 2014, Gemalto M2M GmbH
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice,
+ *       this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice,
+ *       this list of conditions and the following disclaimer in the documentation
+ *       and/or other materials provided with the distribution.
+ *     * Neither the name of {{ project }} nor the names of its contributors
+ *       may be used to endorse or promote products derived from this software
+ *       without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 package leshan.standalone.servlet;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import leshan.core.node.LwM2mNode;
+import leshan.core.node.LwM2mObjectInstance;
+import leshan.core.node.LwM2mResource;
+import leshan.core.node.Value;
+import leshan.core.request.ContentFormat;
+import leshan.core.response.ClientResponse;
+import leshan.core.response.ValueResponse;
+import leshan.server.LwM2mServer;
+import leshan.server.client.Client;
+import leshan.server.request.CreateRequest;
+import leshan.server.request.DeleteRequest;
+import leshan.server.request.ExecuteRequest;
+import leshan.server.request.ObserveRequest;
+import leshan.server.request.ReadRequest;
+import leshan.server.request.ResourceAccessException;
+import leshan.server.request.WriteRequest;
+import leshan.standalone.servlet.json.ClientSerializer;
+import leshan.standalone.servlet.json.LwM2mNodeDeserializer;
+import leshan.standalone.servlet.json.LwM2mNodeSerializer;
+import leshan.standalone.servlet.json.ResponseSerializer;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jetty.http.HttpFields;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
 
 /**
  * Service HTTP REST API calls.


### PR DESCRIPTION
fixed CANCEL observe issue..
It is a bug in client servlet line 285 -> added forward slash before observe
before:
String target = StringUtils.substringsBetween(req.getPathInfo(), clientEndpoint, "observe")[0];
after:
String target = StringUtils.substringsBetween(req.getPathInfo(), clientEndpoint, "/observe")[0];

TARGET always = /objectId/objectInstance/resourceId/  ----- in ObservationRegistryImpl.java line 118, the key in the map does't contain the forward slash at the end..

I changed doPost also line 205 clientServlet.java.
